### PR TITLE
Add example docker compose file

### DIFF
--- a/advanced/docker.mdx
+++ b/advanced/docker.mdx
@@ -214,6 +214,69 @@ docker run -d \
   --code <your-worker-code>
 ```
 
+### Docker Compose Configuration
+
+For easier management of multiple containers, you can use Docker Compose. This is particularly useful when running multiple GPU instances or managing complex deployments.
+
+Create a `docker-compose.yml` file:
+
+```yaml
+services:
+  instance-0:
+    image: inferencedevnet/amd64-nvidia-inference-node:latest
+    command: --code <registry-code>
+    restart: always
+    environment:
+      CONFIG_DIR: /root/.inference
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    volumes:
+      - /root:/root/.inference
+
+  instance-1:
+    image: inferencedevnet/amd64-nvidia-inference-node:latest
+    command: --code <registry-code>
+    restart: always
+    environment:
+      CONFIG_DIR: /root/.inference
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["1"]
+              capabilities: [gpu]
+    volumes:
+      - /root:/root/.inference
+```
+
+To deploy with Docker Compose:
+
+```bash
+# Start all services
+docker-compose up -d
+
+# View logs for all services
+docker-compose logs -f
+
+# Stop all services
+docker-compose down
+
+# Restart a specific instance
+docker-compose restart instance-0
+```
+
+This configuration automatically handles:
+- GPU device assignment for each container
+- Persistent volume mounting for configuration
+- Automatic restart on failure
+- Proper environment variable setup
+
 ## Troubleshooting
 
 ### Container Startup Issues


### PR DESCRIPTION
A new "Docker Compose Configuration" subsection was added to `advanced/docker.mdx`.

This section introduces:
*   An example `docker-compose.yml` file.
    *   It defines two `inference-node` services, `instance-0` and `instance-1`, each configured to utilize a specific GPU (`device_ids: ["0"]` and `device_ids: ["1"]` respectively).
    *   Each service includes `restart: always`, `CONFIG_DIR` environment variable, and a volume mount for persistent storage.
*   Common Docker Compose commands for deployment (`docker-compose up -d`), logging (`docker-compose logs -f`), stopping (`docker-compose down`), and restarting specific services (`docker-compose restart instance-0`).
*   A summary of benefits, such as automatic GPU assignment, persistent volume mounting, and restart policies.

The addition provides a streamlined method for managing multiple GPU instances, complementing the existing manual multi-GPU `docker run` examples.